### PR TITLE
[#9] 지도 REST API 연동

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -6,6 +6,7 @@ import { UsersModule } from './users/users.module';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from './auth/auth.module';
 import { ormConfig } from 'orm.config';
+import { KakaoMapModule } from './kakaomap/map.module';
 
 @Module({
   imports: [
@@ -23,7 +24,8 @@ import { ormConfig } from 'orm.config';
       useFactory: ormConfig
     }),
     UsersModule,
-    AuthModule
+    AuthModule,
+    KakaoMapModule
   ],
   controllers: [AppController],
   providers: [AppService]

--- a/src/kakaomap/map.controller.spec.ts
+++ b/src/kakaomap/map.controller.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { KakaoMapController } from './map.controller';
+
+describe('MapController', () => {
+  let controller: KakaoMapController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [KakaoMapController]
+    }).compile();
+
+    controller = module.get<KakaoMapController>(KakaoMapController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/kakaomap/map.controller.ts
+++ b/src/kakaomap/map.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { KakaoMapService } from './map.service';
+
+@Controller('map')
+export class KakaoMapController {
+  constructor(private readonly kakaoMapService: KakaoMapService) {}
+
+  @Get('/search/:inputQuery')
+  async searchMap(@Param('inputQuery') inputQuery: string) {
+    return this.kakaoMapService.searchAddress(inputQuery);
+  }
+}

--- a/src/kakaomap/map.module.ts
+++ b/src/kakaomap/map.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { KakaoMapController } from './map.controller';
+import { KakaoMapService } from './map.service';
+
+@Module({
+  controllers: [KakaoMapController],
+  providers: [KakaoMapService]
+})
+export class KakaoMapModule {}

--- a/src/kakaomap/map.service.spec.ts
+++ b/src/kakaomap/map.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { KakaoMapService } from './map.service';
+
+describe('MapService', () => {
+  let service: KakaoMapService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [KakaoMapService]
+    }).compile();
+
+    service = module.get<KakaoMapService>(KakaoMapService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/kakaomap/map.service.ts
+++ b/src/kakaomap/map.service.ts
@@ -1,0 +1,20 @@
+import { Injectable, Inject } from '@nestjs/common';
+import axios from 'axios';
+
+@Injectable()
+export class KakaoMapService {
+  constructor() {}
+
+  async searchAddress(inputQuery: string) {
+    const url = `https://dapi.kakao.com/v2/local/search/keyword`;
+    const response = await axios.get(url, {
+      headers: {
+        Authorization: `KakaoAK ` + process.env.REST_API_KEY
+      },
+      params: {
+        query: inputQuery
+      }
+    });
+    return response.data.documents;
+  }
+}


### PR DESCRIPTION
## 카카오Map REST API 연동
- REST API 키 발급
- 검색어 입력시 연관 검색 결과 반환되도록 구현